### PR TITLE
chore: update dependencies

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -107,7 +107,7 @@
       "type": "override"
     },
     {
-      "name": "cookies",
+      "name": "cookie",
       "version": "^0.7.0",
       "type": "override"
     },

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -107,6 +107,11 @@
       "type": "override"
     },
     {
+      "name": "cookies",
+      "version": "^0.7.0",
+      "type": "override"
+    },
+    {
       "name": "dompurify",
       "version": "^3.1.3",
       "type": "override"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -109,6 +109,7 @@ monorepo.package.addPackageResolutions(
   "aws-cdk-lib@^2.155.0",
   "axios@^1.7.4",
   "body-parser@^1.20.3",
+  "cookies@^0.7.0",
   "dompurify@^3.1.3",
   "express@^4.20.0",
   "fast-xml-parser@^4.4.1",

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -109,7 +109,7 @@ monorepo.package.addPackageResolutions(
   "aws-cdk-lib@^2.155.0",
   "axios@^1.7.4",
   "body-parser@^1.20.3",
-  "cookies@^0.7.0",
+  "cookie@^0.7.0",
   "dompurify@^3.1.3",
   "express@^4.20.0",
   "fast-xml-parser@^4.4.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
       "aws-cdk-lib": "^2.155.0",
       "axios": "^1.7.4",
       "body-parser": "^1.20.3",
+      "cookies": "^0.7.0",
       "dompurify": "^3.1.3",
       "express": "^4.20.0",
       "fast-xml-parser": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
       "aws-cdk-lib": "^2.155.0",
       "axios": "^1.7.4",
       "body-parser": "^1.20.3",
-      "cookies": "^0.7.0",
+      "cookie": "^0.7.0",
       "dompurify": "^3.1.3",
       "express": "^4.20.0",
       "fast-xml-parser": "^4.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   aws-cdk-lib: ^2.155.0
   axios: ^1.7.4
   body-parser: ^1.20.3
+  cookies: ^0.7.0
   dompurify: ^3.1.3
   express: ^4.20.0
   fast-xml-parser: ^4.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   aws-cdk-lib: ^2.155.0
   axios: ^1.7.4
   body-parser: ^1.20.3
-  cookies: ^0.7.0
+  cookie: ^0.7.0
   dompurify: ^3.1.3
   express: ^4.20.0
   fast-xml-parser: ^4.4.1
@@ -8291,11 +8291,6 @@ packages:
 
   /cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
-    dev: false
-
-  /cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
-    engines: {node: '>= 0.6'}
     dev: false
 
   /cookie@0.7.1:
@@ -17196,7 +17191,7 @@ packages:
       '@swagger-api/apidom-json-pointer': 1.0.0-alpha.9
       '@swagger-api/apidom-ns-openapi-3-1': 1.0.0-alpha.9
       '@swagger-api/apidom-reference': 1.0.0-alpha.9
-      cookie: 0.6.0
+      cookie: 0.7.1
       deepmerge: 4.3.1
       fast-json-patch: 3.1.1
       js-yaml: 4.1.0


### PR DESCRIPTION
This commit updates the following dependencies:

- `cookie` from `^0.6.0` to `^0.7.0`

The updates are necessary to address potential security vulnerabilities or
compatibility issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
